### PR TITLE
Make the atom feed valid

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Blog posts are in the `articles` folder.
 ## Installation
 
 ```
-make install
+make vendor
 ```
 
 ## Preview

--- a/src/Controller/IndexController.php
+++ b/src/Controller/IndexController.php
@@ -25,6 +25,7 @@ class IndexController extends AbstractController
     {
         $feed = new Feed;
         $feed->setTitle('Matthieu Napoli\'s blog');
+        $feed->setPublicId('https://mnapoli.fr/');
 
         $lastUpdate = null;
 
@@ -34,7 +35,9 @@ class IndexController extends AbstractController
             $articleDate = new \DateTime($article->date->format('Y-m-d H:i'));
             $lastUpdate = max($lastUpdate, $articleDate);
             $item->setLastModified($articleDate);
-            $item->setLink('/' . $article->slug . '/');
+            $item->setLink('https://mnapoli.fr/' . $article->slug . '/');
+            $item->setPublicId('https://mnapoli.fr/' . $article->slug . '/');
+            $item->setAuthor(($item->newAuthor())->setName('Matthieu Napoli'));
 
             $feed->add($item);
         }


### PR DESCRIPTION
There were some errors: https://validator.w3.org/feed/check.cgi?url=https%3A%2F%2Fmnapoli.fr%2Fatom.xml

- the feed needs an id (the website url)
- each item needs an id (the entry url)
- each item needs an author

With this PR:
![image](https://user-images.githubusercontent.com/62333/63346055-7a6ace80-c354-11e9-93a9-29cd6b724e74.png)

Also, `make install` does not exist (as explained in the README) I guess it should be `make vendor` instead.